### PR TITLE
tried to get relation to only show name and id fields, failed at that

### DIFF
--- a/app/controllers/directors_controller.rb
+++ b/app/controllers/directors_controller.rb
@@ -10,7 +10,8 @@ class DirectorsController < ApplicationController
 
   # GET /directors/1
   def show
-    render json: @director, include: { docs: { only: [:name, :id, :year] } }
+    # render json: @director, include: { docs: { only: [:name, :id, :year] } }
+    render json: @director
   end
 
   # POST /directors

--- a/app/controllers/docs_controller.rb
+++ b/app/controllers/docs_controller.rb
@@ -10,7 +10,8 @@ class DocsController < ApplicationController
 
   # GET /docs/1
   def show
-    render json: @doc, include: { directors: { only: [:name, :id] } }
+    # render json: @doc, include: { directors: { only: [:name, :id] } }
+    render json: @doc
   end
 
   # POST /docs

--- a/app/serializers/director_serializer.rb
+++ b/app/serializers/director_serializer.rb
@@ -1,0 +1,6 @@
+class DirectorSerializer < ActiveModel::Serializer
+  attributes :id, :name, :useful_links, :photo, :bio_short, :bio_long, :bio_source
+  # attributes :id, :name, :useful_links, :photo, :bio_short, :bio_long, :bio_source, :docs
+
+  has_many :docs
+end

--- a/app/serializers/doc_serializer.rb
+++ b/app/serializers/doc_serializer.rb
@@ -1,0 +1,7 @@
+class DocSerializer < ActiveModel::Serializer
+  attributes :id, :name, :chinese_name, :year, :duration, :poster, :doc_text_short, :doc_text_long, :doc_text_source, :awards, :trailer_link, :useful_links
+  # attributes :id, :name, :chinese_name, :year, :duration, :poster, :doc_text_short, :doc_text_long, :doc_text_source, :awards, :trailer_link, :useful_links, :directors
+  has_many :directors
+end
+
+

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json_api


### PR DESCRIPTION
Tried to get only 'name' and 'id' fields showing in relationships. Failed.
Apparently JSON API spec is that  it differentiates between "resources" (actual objects) and "resource identifiers" (only type and id, which are basically references to other resources). When a resource is referenced as a relationship for an other resource, only its resource identifier appears."